### PR TITLE
Efer/tweaks

### DIFF
--- a/src/media/event.rs
+++ b/src/media/event.rs
@@ -1,7 +1,7 @@
 use std::ops::RangeInclusive;
 use std::time::Instant;
 
-use crate::rtp::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid, SeqNo, Ssrc};
+use crate::rtp::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid, SeqNo};
 use crate::sdp::Simulcast as SdpSimulcast;
 
 use super::PayloadParams;
@@ -97,9 +97,6 @@ pub struct MediaData {
     /// This is a newer standard that is sometimes used in WebRTC to identify
     /// a stream. Specifically when using Simulcast in Chrome.
     pub rid: Option<Rid>,
-
-    ///
-    pub ssrc: Option<Ssrc>,
 
     /// Parameters for the codec. This is used to match incoming PT to outgoing PT.
     pub params: PayloadParams,

--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1246,7 +1246,6 @@ impl MediaInner {
                         mid: self.mid,
                         pt: *pt,
                         rid: *rid,
-                        ssrc: dep.meta.get(0).map(|meta| meta.header.ssrc),
                         params: codec,
                         time: dep.time,
                         network_time: dep.first_network_time(),

--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1322,10 +1322,11 @@ impl MediaInner {
         self.simulcast = Some(s);
     }
 
-    pub fn ssrc_rx_for_rid(&self, repairs: Rid) -> Option<Ssrc> {
+    pub fn ssrc_rx_for_rid(&self, repairs: Option<Rid>, ignore_ssrc: Ssrc) -> Option<Ssrc> {
+        // Find the most recent matching ssrc, in case the ssrc has changed.
         self.sources_rx
             .iter()
-            .find(|r| r.rid() == Some(repairs))
+            .rfind(|r| r.rid() == repairs && r.ssrc() != ignore_ssrc)
             .map(|r| r.ssrc())
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -445,9 +445,10 @@ impl Session {
 
             let n = RtpHeader::read_original_sequence_number(&data, &mut orig_seq_16);
             data.drain(0..n);
-            info!(
+            trace!(
                 "Repaired seq no {} -> {}",
-                header.sequence_number, orig_seq_16
+                header.sequence_number,
+                orig_seq_16
             );
             header.sequence_number = orig_seq_16;
             if let Some(repairs_rid) = header.ext_vals.rid_repair {
@@ -461,7 +462,7 @@ impl Session {
                     return;
                 }
             };
-            info!("Repaired {:?} -> {:?}", header.ssrc, repaired_ssrc);
+            trace!("Repaired {:?} -> {:?}", header.ssrc, repaired_ssrc);
             header.ssrc = repaired_ssrc;
 
             let repaired_source = media.get_or_create_source_rx(repaired_ssrc);


### PR DESCRIPTION
- Associate RTX payloads without RIDs with main SSRCs
- Update rtp packets received over RTX in rtp_mode to include the "repaired" header (pt, seqno, and ssrc).
- Remove the SSRC exposure since we don't need it now that the packet has been repaired here.